### PR TITLE
limit user notification api to 1 month

### DIFF
--- a/lib/mediators/notifications/lister.rb
+++ b/lib/mediators/notifications/lister.rb
@@ -8,6 +8,7 @@ module Mediators::Notifications
       Notification
        .eager_graph(:message=>:followup)
        .where(user: @user)
+       .where("notifications.created_at > now() - '1 month'::interval")
        .order(Sequel.desc(:created_at))
        .all
     end

--- a/spec/mediators/notifications/lister_spec.rb
+++ b/spec/mediators/notifications/lister_spec.rb
@@ -30,9 +30,9 @@ describe Mediators::Notifications::Lister, '#call' do
 
     it 'does not include notificaitons for other users' do
       user2 = Fabricate(:user)
-      note = Fabricate(:notification, user_id: user2.id, message_id: @m1.id, created_at: DateTime.new(2012,2,2))
+      note = Fabricate(:notification, user: user2)
 
-      expect(lister.call).to_not match(note)
+      expect(lister.call).to_not include(note)
     end
 
     it 'only makes one query even when the associated parts are touched' do

--- a/spec/mediators/notifications/lister_spec.rb
+++ b/spec/mediators/notifications/lister_spec.rb
@@ -19,13 +19,19 @@ describe Mediators::Notifications::Lister, '#call' do
       @m1 = Fabricate(:message, producer: @p1)
       @m2 = Fabricate(:message, producer: @p1)
       @f1 = Fabricate(:followup, message: @m1)
-      @n1 = Fabricate(:notification, user: @user, message: @m1, created_at: DateTime.new(2012,2,2))
-      @n2 = Fabricate(:notification, user: @user, message: @m2, created_at: DateTime.new(2014,4,4))
+      @n1 = Fabricate(:notification, user: @user, message: @m1, created_at: DateTime.now - 1)
+      @n2 = Fabricate(:notification, user: @user, message: @m2, created_at: DateTime.now)
     end
 
     it 'returns the notifications in a sorted array' do
       expect(@n2.created_at).to be > @n1.created_at
       expect(lister.call).to eq([@n2, @n1])
+    end
+
+    it 'does not include notificaitons for older than one month' do
+      @m3 = Fabricate(:message, producer: @p1)
+      @n3 = Fabricate(:notification, user: @user, message: @m3, created_at: DateTime.now - 35)
+      expect(lister.call).to_not include(@n3)
     end
 
     it 'does not include notificaitons for other users' do

--- a/spec/serializers/user_api/notification_serializer_spec.rb
+++ b/spec/serializers/user_api/notification_serializer_spec.rb
@@ -4,14 +4,14 @@ describe Serializers::UserAPI::NotificationSerializer do
   let(:sz) { described_class.new(:default) }
 
   before do
-    @note = Fabricate(:notification, created_at: DateTime.new(2012,2,2))
+    @note = Fabricate(:notification, created_at: DateTime.new(3012,2,2)) # intentionally in the future
     @notes = Mediators::Notifications::Lister.run(user: @note.user)
   end
 
   it 'can use whatever the lister mediator generates' do
     json = MultiJson.encode(sz.serialize(@notes))
     expect(json).to match(@note.message.body)
-    expect(json).to match('2012-02-02T00:00:00Z') # the Z is required for firefox!
+    expect(json).to match('3012-02-02T00:00:00Z') # the Z is required for firefox!
   end
 
   it 'adds read based on read_at' do


### PR DESCRIPTION
We still should have a mark/sweep thing to clear out old stuff to nip tables growing forever in the bud, but for now this makes the user api a bit nicer.