### PR TITLE
Update addons CLI usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ $ bin/setup
 To deploy to the platform:
 
 ```
-h addons:add hpg:s0
+h addons:create heroku-postgresql:standard-0
 h pg:promote <that database>
-h addons:add mailgun
-h addons:add redisgreen
-h addons:add pgbackups:auto-month
+h addons:create mailgun
+h addons:create redisgreen
+h addons:create pgbackups:auto-month
 h config:add REDIS_PROVIDER=REDISGREEN_URL
 h config:set API_KEY_HMAC_SECRET=$(dd if=/dev/urandom bs=127 count=1 2>/dev/null | openssl base64 -A)
 h config:set HEROKU_API_URL=https://telex:<key>@api.heroku.com


### PR DESCRIPTION
Given the semantic changes introduced by Shareable Add-ons, the command to
provision an add-on for an application is now `addons:create`. The `addons:add`
command will continue to work for some time with a warning message displayed.

Thanks! :)