### PR TITLE
Improve ember client support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -55,7 +55,7 @@ GEM
     http_accept (0.1.6)
     i18n (0.7.0)
     json (1.8.3)
-    json_schema (0.6.0)
+    json_schema (0.6.2)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -65,22 +65,20 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.1)
-    minitest (5.7.0)
-    multi_json (1.11.1)
+    minitest (5.8.0)
+    multi_json (1.11.2)
     nenv (0.2.0)
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
     oj (2.12.9)
     pg (0.18.2)
-    pliny (0.8.2)
+    pliny (0.11.1)
       activesupport (~> 4.1, >= 4.1.0)
       http_accept (~> 0.1, >= 0.1.5)
       multi_json (~> 1.9, >= 1.9.3)
-      pg (~> 0.17, >= 0.17.1)
       prmd (~> 0.7.0)
       rack-timeout (~> 0.2, >= 0.2.3)
-      sequel (~> 4.9, >= 4.9.0)
       sinatra (~> 1.4, >= 1.4.5)
       sinatra-router (~> 0.2, >= 0.2.3)
       thor (~> 0.19, >= 0.19.1)
@@ -210,3 +208,6 @@ DEPENDENCIES
   sinatra-router
   sucker_punch
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/lib/middleware/user_authenticator.rb
+++ b/lib/middleware/user_authenticator.rb
@@ -9,12 +9,15 @@ module Middleware
         return @app.call(env)
       end
 
-      auth = Rack::Auth::Basic::Request.new(env)
-      unless auth.provided? && auth.basic? && auth.credentials
-        raise Pliny::Errors::Unauthorized
+      if /Bearer/.match(env['HTTP_AUTHORIZATION'])
+        api_key = /\ABearer (.+)\z/.match(env['HTTP_AUTHORIZATION'])[1]
+      else
+        auth = Rack::Auth::Basic::Request.new(env)
+        unless auth.provided? && auth.basic? && auth.credentials
+          raise Pliny::Errors::Unauthorized
+        end
+        _, api_key = auth.credentials
       end
-
-      _, api_key = auth.credentials
 
       user = lookup_user(key: api_key)
 


### PR DESCRIPTION
This PR updates pliny to include additional headers required to support CORS requests. It also adds support for telex to use a bearer token from the Authorization header instead of just basic auth.