### PR TITLE
Email org admins directly and uniquely

### DIFF
--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -27,6 +27,10 @@ module Telex
       get("/apps/#{app_uuid}/collaborators")
     end
 
+    def organization_members(organization_name)
+      get("/organizations/#{organization_name}/members")
+    end
+
     private
 
     def client


### PR DESCRIPTION
When the app owner is an organization, notify each owner separately (and only once).

cc @wuputah 
Fix #43 