### PR TITLE
When GETting apps, get deleted ones too

### DIFF
--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -20,7 +20,10 @@ module Telex
     end
 
     def app_info(app_uuid)
-      get("/apps/#{app_uuid}")
+      get(
+        "/apps/#{app_uuid}",
+        "X-Heroku-Include-Deleted-Apps" => true
+      )
     end
 
     def app_collaborators(app_uuid)


### PR DESCRIPTION
Telex is getting a number of 404s when trying to look up Apps. This is probably happening because the Apps have been deleted. Still, there are probably several legitimate reasons to notify on an app that has been deleted–particularly right after it has been. So let's let Telex get apps whether they're deleted or not.