### PR TITLE
Fix Gmail go to action attributes

### DIFF
--- a/lib/telex/emailer.rb
+++ b/lib/telex/emailer.rb
@@ -73,11 +73,12 @@ class Telex::Emailer
     {
       "@context" => "http://schema.org",
       "@type" => "EmailMessage",
-      "action" => {
+      "potentialAction" => {
         "@type" => "ViewAction",
-        "url" => action[:url],
+        "target" => action[:url],
         "name" => action[:label]
-      }
+      },
+      "description" => action[:label]
     }
   end
 end

--- a/spec/telex/emailer_spec.rb
+++ b/spec/telex/emailer_spec.rb
@@ -31,9 +31,9 @@ describe Telex::Emailer do
       expect(script.attributes["type"]).to eq('application/ld+json')
       ld_json = MultiJson.load(script.text)
       expect(ld_json['@context']).to eq('http://schema.org')
-      expect(ld_json['action']['@type']).to eq('ViewAction') # only supported Gmail type for now
-      expect(ld_json['action']['name']).to eq('View app')
-      expect(ld_json['action']['url']).to eq('https://foo')
+      expect(ld_json.dig('potentialAction', '@type')).to eq('ViewAction') # only supported Gmail type for now
+      expect(ld_json.dig('potentialAction', 'name')).to eq('View app')
+      expect(ld_json.dig('potentialAction', 'target')).to eq('https://foo')
     end
   end
 end


### PR DESCRIPTION
It seems the attributes have diverged:

https://developers.google.com/gmail/markup/reference/go-to-action#use_cases