### PR TITLE
Stop rollbar from reporting 404s

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -24,8 +24,12 @@ module Endpoints
       also_reload '../**/*.rb'
     end
 
-    error Pliny::Errors::Error do
-      Pliny::Errors::Error.render(env["sinatra.error"])
+    error Pliny::Errors::HTTPStatusError do
+      # Set the error status here so Pliny::Extensions::Instruments reports it
+      # properly.
+      status env["sinatra.error"].status
+      # Re-raising so Pliny::Middleware::RescueErrors can handle it.
+      raise env["sinatra.error"]
     end
 
     not_found do

--- a/spec/endpoints/producer_api/messages_spec.rb
+++ b/spec/endpoints/producer_api/messages_spec.rb
@@ -3,6 +3,13 @@ require "spec_helper"
 describe Endpoints::ProducerAPI::Messages do
   include Rack::Test::Methods
 
+  def app
+    Rack::Builder.new do
+      use Pliny::Middleware::RescueErrors  # so we get status, not exceptions
+      run Endpoints::ProducerAPI::Messages
+    end
+  end
+
   before do
     @producer = Fabricate(:producer)
     Pliny::RequestStore.store[:current_producer] = @producer


### PR DESCRIPTION
Rollbar has been spamming us with reporting legit 404 responses to requests.
This updates `Endpoints::Base` to re-raise `HTTPStatusError`s so Pliny middleware can handle it --
`Pliny::Middleware::RescueErrors` properly cleans the Sinatra error state so the Rollbar middleware won't report on errors that the app itself is returning.

/cc @heroku/api 