### PR TITLE
Protect against Notification unique constraint violations 

### DIFF
--- a/lib/mediators/notifications/creator.rb
+++ b/lib/mediators/notifications/creator.rb
@@ -13,7 +13,7 @@ module Mediators::Notifications
       # Notification already queued, just ignore.
       Pliny.log(duplicate_notificaiton: true, user_id: user.id, message_id: message.id)
     rescue => e
-      # ^ Typically a email send failure.
+      # ^ Typically an email send failure.
       # Remove the notification before we re-raise so the mediator can be run
       # again.
       Notification.where(user_id: user.id, message_id: message.id).delete

--- a/lib/mediators/notifications/creator.rb
+++ b/lib/mediators/notifications/creator.rb
@@ -1,7 +1,7 @@
 module Mediators::Notifications
   class Creator < Mediators::Base
     def initialize(user:, message:)
-      self.user = user
+      self.user    = user
       self.message = message
     end
 
@@ -9,6 +9,15 @@ module Mediators::Notifications
       self.notification = Notification.create(user_id: user.id, message_id: message.id)
       send_email
       notification
+    rescue Sequel::ValidationFailed, Sequel::UniqueConstraintViolation
+      # Notification already queued, just ignore.
+      Pliny.log(duplicate_notificaiton: true, user_id: user.id, message_id: message.id)
+    rescue => e
+      # ^ Typically a email send failure.
+      # Remove the notification before we re-raise so the mediator can be run
+      # again.
+      Notification.where(user_id: user.id, message_id: message.id).delete
+      raise e
     end
 
     private

--- a/lib/models/notification.rb
+++ b/lib/models/notification.rb
@@ -3,5 +3,10 @@ class Notification < Sequel::Model
   many_to_one :message
 
   plugin :timestamps
+  plugin :validation_helpers
 
+  def validate
+    super
+    validates_unique %i[user message]
+  end
 end

--- a/spec/mediators/notifications/creator_spec.rb
+++ b/spec/mediators/notifications/creator_spec.rb
@@ -9,5 +9,22 @@ describe Mediators::Notifications::Creator do
     result = nil
     expect{ result = @creator.call }.to change(Notification, :count).by(1)
     expect(result).to be_instance_of(Notification)
+    expect(Mail::TestMailer.deliveries.count).to be(1)
+  end
+
+  it 'does not send duplicate messages' do
+    expect do
+      @creator.call
+      @creator.call
+    end.to change(Notification, :count).by(1)
+
+    expect(Mail::TestMailer.deliveries.count).to be(1)
+  end
+
+  it 'removes the Notification object on message send failures' do
+    allow(Telex::Emailer).to receive(:new) { raise Net::ReadTimeout }
+    expect{ @creator.call }.to raise_error Net::ReadTimeout
+    expect(Mail::TestMailer.deliveries.count).to be(0)
+    expect(Notification.count).to be(0)
   end
 end


### PR DESCRIPTION
We get a lot of these: https://rollbar.com/Heroku-3/telex/items/127/

When an email fails to send, it throws an error which re-enqueues the job. Unfortunately by this time the Notification has already been saved to the database and we have no way to know that the message failed. Trying to recreate the message causes the `Sequel::UniqueConstraintViolation` because the row already exists. The job continues to fail until it 

This change handles the duplicate case and stops the job from being run again. Any other errors will remove the notification from the DB so the job can run again unhindered.

/cc @heroku/api 