### PR TITLE
Wrap Sinatra 404s in Pliny NotFound error

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -24,18 +24,16 @@ module Endpoints
       also_reload '../**/*.rb'
     end
 
+    error Sinatra::NotFound do
+      raise Pliny::Errors::NotFound
+    end
+
     error Pliny::Errors::HTTPStatusError do
       # Set the error status here so Pliny::Extensions::Instruments reports it
       # properly.
       status env["sinatra.error"].status
       # Re-raising so Pliny::Middleware::RescueErrors can handle it.
       raise env["sinatra.error"]
-    end
-
-    not_found do
-      content_type :json
-      status 404
-      "{}"
     end
   end
 end


### PR DESCRIPTION
Fixes https://rollbar.com/Heroku-3/telex/items/130/

This brings `Endpoints::Base` up to date with how Pliny's template does it now:
https://github.com/interagent/pliny/blob/master/lib/template/lib/endpoints/base.rb#L20-L22

It catches any `Sinatra::NotFound` errors and instead raises `Pliny::Errors::NotFound`. This way `Pliny::Middleware::RescueErrors` can handle it properly (though seems like the middleware should handle it as well ¯\\\_(ツ)\_/¯ ) . The existing `not_found` handler does catch the errors though still seems to raise `Sinatra::NotFound` causing the rollbars we see.

/cc @heroku/api 