### PR TITLE
Handle 404s from Heroku API Requests

### DIFF
--- a/lib/mediators/messages/user_finder.rb
+++ b/lib/mediators/messages/user_finder.rb
@@ -104,6 +104,8 @@ module Mediators::Messages
         # This filters out users who have never logged in
         UserUserFinder.run(target_id: user[:hid]).present?
       end
+    rescue Telex::HerokuClient::NotFound
+      self.users_details = [ ]
     end
   end
 end

--- a/lib/mediators/messages/user_finder.rb
+++ b/lib/mediators/messages/user_finder.rb
@@ -74,7 +74,7 @@ module Mediators::Messages
       else
         self.users_details = [ ]
       end
-    rescue Excon::Errors::NotFound
+    rescue Telex::HerokuClient::NotFound
       self.users_details = [ ]
     end
   end

--- a/lib/mediators/messages/user_finder.rb
+++ b/lib/mediators/messages/user_finder.rb
@@ -69,12 +69,13 @@ module Mediators::Messages
         raise "Mismatching ids, asked for #{target_id}, got #{id}"
       end
 
-      if last_login = user_response.fetch('last_login')
+      if user_response.fetch('last_login')
         self.users_details = [ extract_user(:self, user_response) ]
       else
         self.users_details = [ ]
       end
-
+    rescue Excon::Errors::NotFound
+      self.users_details = [ ]
     end
   end
 

--- a/lib/middleware/user_authenticator.rb
+++ b/lib/middleware/user_authenticator.rb
@@ -53,7 +53,7 @@ module Middleware
       cache_store(user_id: user.id, key: key)
 
       user
-    rescue Excon::Errors::Error
+    rescue Excon::Errors::Error, Telex::HerokuClient::NotFound
       nil
     end
 

--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -73,14 +73,18 @@ module Telex
         path:    path)
       content = MultiJson.decode(response.body)
 
-      if response.status == 206 && response.headers.key?('Next-Range')
-        content.concat get(path, {
-          range: response.headers['Next-Range']
-        }.merge(options))
+      if more_data? response
+        opts = {range: response.headers['Next-Range'] }.merge(options)
+        content.concat get(path, opts)
       end
+
       content
     rescue Excon::Errors::NotFound
       raise Telex::HerokuClient::NotFound
+    end
+
+    def more_data?(response)
+      response.status == 206 && response.headers.key?('Next-Range')
     end
   end
 end

--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -1,6 +1,9 @@
 require 'uri'
 module Telex
   class HerokuClient
+
+    class NotFound < StandardError ; end
+
     attr_accessor :uri
     private :uri=
 
@@ -76,6 +79,8 @@ module Telex
         }.merge(options))
       end
       content
+    rescue Excon::Errors::NotFound
+      raise Telex::HerokuClient::NotFound
     end
   end
 end

--- a/spec/mediators/messages/user_finder_spec.rb
+++ b/spec/mediators/messages/user_finder_spec.rb
@@ -52,22 +52,29 @@ describe UserUserFinder, "#call" do
     expect(uwr.user.heroku_id).to eq(@id)
   end
 
-  describe "a user who has never logged in" do
-    before do
-      stub_heroku_api do
-        get "/account" do
-          MultiJson.encode(
-            id:         env["HTTP_USER"],
-            email:      "username@example.com",
-            last_login: nil)
-        end
+  it 'excludes users that have never logged in' do
+    stub_heroku_api do
+      get "/account" do
+        MultiJson.encode(
+          id:         env["HTTP_USER"],
+          email:      "username@example.com",
+          last_login: nil)
       end
     end
 
-    it "is excluded" do
-      response = @finder.call
-      expect(response).to be_empty
+    response = @finder.call
+    expect(response).to be_empty
+  end
+
+  it 'excludes missing users' do
+    stub_heroku_api do
+      get "/account" do
+        raise Excon::Errors::NotFound, "not found"
+      end
     end
+
+    response = @finder.call
+    expect(response).to be_empty
   end
 end
 

--- a/spec/mediators/messages/user_finder_spec.rb
+++ b/spec/mediators/messages/user_finder_spec.rb
@@ -204,4 +204,38 @@ describe AppUserFinder, "#call" do
     response = @finder.call
     expect(response).to be_empty
   end
+
+  it "handles missing org lookups" do
+    stub_heroku_api do
+      get "/apps/:id" do |id|
+        MultiJson.encode(
+          name: "example",
+          owner: {
+            id:    SecureRandom.uuid,
+            email: "organization@herokumanager.com",
+          })
+      end
+
+      get "/organizations/:name/members" do
+        raise Excon::Errors::NotFound, "not found"
+      end
+    end
+    result = @finder.call
+    emails = result.map {|role| role.user[:email] }
+    # only the collaborators
+    expect(emails.sort).to eq(%w[username2@example.com username3@example.com])
+  end
+
+  it "handles missing collaborator lookups" do
+    stub_heroku_api do
+      get "/apps/:id/collaborators" do
+        raise Excon::Errors::NotFound, "not found"
+      end
+    end
+
+    result = @finder.call
+    emails = result.map {|role| role.user[:email] }
+    # only the owner since we got that on the first call
+    expect(emails).to eq(%w[username@example.com])
+  end
 end

--- a/spec/telex/heroku_client_spec.rb
+++ b/spec/telex/heroku_client_spec.rb
@@ -40,4 +40,13 @@ describe Telex::HerokuClient, '#new' do
 
     expect(client.organization_members('foobar')).to eql([{'id' => 1}, {'id' => 2}])
   end
+
+  it 'raises a NotFound error on 404s' do
+    client = Telex::HerokuClient.new
+    stub_request(:get, "#{client.uri}/organizations/foobar/members").
+      to_return(status: 404)
+
+    expect { client.organization_members('foobar') }.
+      to raise_error(Telex::HerokuClient::NotFound)
+  end
 end


### PR DESCRIPTION
https://rollbar.com/Heroku-3/telex/items/139/

Currently we just blow up if an API request returns a 404 when looking up Users, Apps or Orgs. In this case, we need to silently ignore it since no users can be found to actually send messages to.

/cc @heroku/api 