### PR TITLE
Gracefully handle email errors

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -37,6 +37,10 @@ unless Config.rack_env == 'test'
       user_session_secret
       www-sso-session
     ]
+
+    config.exception_level_filters.merge!(
+      'Telex::Emailer::DeliveryError' => 'warning'
+    )
   end
 
   require 'rollbar/sidekiq'

--- a/lib/telex/emailer.rb
+++ b/lib/telex/emailer.rb
@@ -50,7 +50,7 @@ class Telex::Emailer
       from:            from,
       notification_id: notification_id
     )
-    raise DeliveryError
+    raise DeliveryError.new(e.message)
   end
 
   private

--- a/spec/mediators/notifications/creator_spec.rb
+++ b/spec/mediators/notifications/creator_spec.rb
@@ -22,8 +22,8 @@ describe Mediators::Notifications::Creator do
   end
 
   it 'removes the Notification object on message send failures' do
-    allow(Telex::Emailer).to receive(:new) { raise Net::ReadTimeout }
-    expect{ @creator.call }.to raise_error Net::ReadTimeout
+    allow(Telex::Emailer).to receive(:new) { raise Telex::Emailer::DeliveryError }
+    expect{ @creator.call }.to raise_error Telex::Emailer::DeliveryError
     expect(Mail::TestMailer.deliveries.count).to be(0)
     expect(Notification.count).to be(0)
   end


### PR DESCRIPTION
There's not much we can do when Mailgun gets a DDOS except to not continually spam us Rollbar notifications.

Fixes #62

/cc @heroku/api 