### PR TITLE
Cleanup the old code path

### DIFF
--- a/lib/endpoints/app_api/recipients.rb
+++ b/lib/endpoints/app_api/recipients.rb
@@ -37,8 +37,6 @@ module Endpoints
         recipient = Mediators::Recipients::Creator.run(
           app_info: @app_info,
           email: data.fetch("email", ""),
-          title: data.fetch("title", ""),
-          body: data.fetch("body", ""),
           template: data.fetch("template", ""),
         )
         status 201
@@ -58,8 +56,6 @@ module Endpoints
           app_info: @app_info,
           recipient: get_recipient,
           active: data.fetch("active", false),
-          title: data.fetch("title", ""),
-          body: data.fetch("body", ""),
           template: data.fetch("template", ""),
         )
         respond_json(recipient)

--- a/lib/mediators/recipients/creator.rb
+++ b/lib/mediators/recipients/creator.rb
@@ -2,16 +2,10 @@ module Mediators::Recipients
   class Creator < Mediators::Base
     attr_reader :app_info, :email, :title, :body
 
-    def initialize(app_info:, email:, template: nil, title: nil, body: nil)
+    def initialize(app_info:, email:, template:)
       @app_info = app_info
       @email = email
-
-      if template.to_s.empty?
-        @title = title
-        @body = body
-      else
-        @title, @body = TemplateFinder.run(template: template)
-      end
+      @title, @body = TemplateFinder.run(template: template)
     end
 
     def call

--- a/lib/mediators/recipients/updater.rb
+++ b/lib/mediators/recipients/updater.rb
@@ -2,15 +2,12 @@ module Mediators::Recipients
   class Updater < Mediators::Base
     attr_reader :app_info, :recipient, :active, :title, :body
 
-    def initialize(app_info:, recipient:, active: false, title: "", body: "", template: "")
+    def initialize(app_info:, recipient:, template: nil, active: false)
       @app_info = app_info
       @recipient = recipient
       @active = active      
 
-      if template.to_s.empty?
-        @title = title
-        @body = body
-      else
+      if template
         @title, @body = TemplateFinder.run(template: template)
       end
     end
@@ -38,7 +35,7 @@ module Mediators::Recipients
     end
 
     def regenerate_token?
-      !title.empty? && !body.empty?
+      !title.to_s.empty? && !body.to_s.empty?
     end
   end
 end

--- a/spec/mediators/recipients/creator_spec.rb
+++ b/spec/mediators/recipients/creator_spec.rb
@@ -6,21 +6,6 @@ describe Mediators::Recipients::Creator do
       "id" => SecureRandom.uuid,
       "name" => "brat",
     }
-    @creator = described_class.new(app_info: @app_info,
-                                   email: "foo@bar.com",
-                                   title: "hello",
-                                   body: "%{app} %{token}")
-  end
-
-  it "DEPRECATED: creates a recipient via title/body directly" do
-    allow(Mediators::Recipients::Emailer).to receive(:run).with(
-      app_info: @app_info, recipient: kind_of(Recipient),
-      title: "hello", body: "%{app} %{token}"
-    )
-    
-    result = nil
-    expect{ result = @creator.call }.to change(Recipient, :count).by(1)
-    expect(result).to be_instance_of(Recipient)
   end
 
   it "creates a recipient via the named template" do

--- a/spec/mediators/recipients/updater_spec.rb
+++ b/spec/mediators/recipients/updater_spec.rb
@@ -13,7 +13,7 @@ describe Mediators::Recipients::Updater do
     expect(recipient.active).to eq(false)
   end
 
-  it "can regenerate a new token when `title` `body` is supplied" do
+  it "can regenerate a new token when `template` is supplied" do
     recipient = Fabricate(:recipient, verification_sent_at: Time.now.utc - 120)
     old_token = recipient.verification_token
 
@@ -21,8 +21,10 @@ describe Mediators::Recipients::Updater do
       app_info: app_info, recipient: recipient, title: "hello", body: "{{app}} {{token}}"
     )
 
-    described_class.run(app_info: app_info, recipient: recipient, title: "hello", body: "{{app}} {{token}}")
-    expect(recipient.verification_token).to_not eq(old_token)
+    Mediators::Recipients::TemplateFinder.setup(template: "alerting", title: "hello", body: "%{app} %{token}") do
+      described_class.run(app_info: app_info, recipient: recipient, template: "alerting")
+      expect(recipient.verification_token).to_not eq(old_token)
+    end
   end
 
   it "can does not regenerate a new token when `refresh_token: false` is supplied" do


### PR DESCRIPTION
With this, the prodsec inquery is complete: We can no longer
accept arbitrary email bodies, and everything has to be whitelisted.