### PR TITLE
Return 404 instead of 422 when there is no muching message

### DIFF
--- a/lib/endpoints/producer_api/messages.rb
+++ b/lib/endpoints/producer_api/messages.rb
@@ -36,6 +36,8 @@ module Endpoints
 
          status 201
          MultiJson.encode({id: followup.id})
+        rescue Pliny::Errors::NotFound => e
+          raise e
         rescue
           raise Pliny::Errors::UnprocessableEntity
         end

--- a/lib/endpoints/producer_api/messages.rb
+++ b/lib/endpoints/producer_api/messages.rb
@@ -27,6 +27,8 @@ module Endpoints
       post '/:message_id/followups' do
         begin
           message = Message[id: params['message_id'], producer_id: current_producer.id]
+          raise Pliny::Errors::NotFound unless message
+
           followup = Mediators::Followups::Creator.run(
             message: message,
             body:    data['body']

--- a/spec/endpoints/producer_api/messages_spec.rb
+++ b/spec/endpoints/producer_api/messages_spec.rb
@@ -99,6 +99,12 @@ describe Endpoints::ProducerAPI::Messages do
     end
 
     context 'with bad params' do
+      it "fails with non existance message" do
+        allow(Message).to receive(:[]).and_return(nil)
+        do_post
+        expect(last_response.status).to eq(404)
+      end
+
       it "fails with an empty body" do
         @followup_body[:body] = ''
         do_post
@@ -114,14 +120,14 @@ describe Endpoints::ProducerAPI::Messages do
       it "fails with a missing message_id" do
         @message.id = SecureRandom.uuid
         do_post
-        expect(last_response.status).to eq(422)
+        expect(last_response.status).to eq(404)
       end
 
       it "fails when the message belongs to a different producer" do
         @message.producer = Fabricate(:producer)
         @message.save
         do_post
-        expect(last_response.status).to eq(422)
+        expect(last_response.status).to eq(404)
       end
     end
 


### PR DESCRIPTION
DoD was seeing the issue that this endpoint returns 422 and had hard time debugging what was going on. 404 is nicer than 422 when there is no matching message (well, we shouldn't send such request first of all but... you know).
cc/ @camilleldn 