### PR TITLE
Update API organization requests to team

### DIFF
--- a/lib/mediators/messages/user_finder.rb
+++ b/lib/mediators/messages/user_finder.rb
@@ -120,22 +120,22 @@ module Mediators::Messages
     def owners
       owner = extract_user(:owner, app_info.fetch('owner'))
       if owner[:email].end_with?('@herokumanager.com')
-        org_users(owner[:email])
+        team_users(owner[:email])
       else
         [ owner ]
       end
     end
 
-    def org_users(owner_email)
-      org_members_response = heroku_client.organization_members(owner_email.split('@').first)
-      org_admins = org_members_response.select { |member| member.fetch('role') == 'admin' }
-      org_admins.map do |admin|
+    def team_users(owner_email)
+      team_members_response = heroku_client.team_members(owner_email.split('@').first)
+      team_admins = team_members_response.select { |member| member.fetch('role') == 'admin' }
+      team_admins.map do |admin|
         extract_user(:owner, admin.fetch('user'))
       end
     rescue Telex::HerokuClient::NotFound
       # Organization is missing
-      Pliny.log(missing_org: true, org: owner_email)
-      Telex::Sample.count "org_not_found"
+      Pliny.log(missing_team: true, team: owner_email)
+      Telex::Sample.count "team_not_found"
       []
     end
 

--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -38,7 +38,7 @@ module Telex
         variant: ".capabilities",
         base_headers_only: base_headers_only,
         body: body.to_json)
-      
+
       raise BadResponse unless response["capabilities"].kind_of?(Array)
       raise BadResponse unless response["capabilities"][0].kind_of?(Hash)
 
@@ -53,8 +53,8 @@ module Telex
       get("/apps/#{app_uuid}/collaborators")
     end
 
-    def organization_members(organization_name)
-      get("/organizations/#{organization_name}/members")
+    def team_members(team_name)
+      get("/teams/#{team_name}/members")
     end
 
     private

--- a/spec/mediators/messages/user_finder_spec.rb
+++ b/spec/mediators/messages/user_finder_spec.rb
@@ -124,18 +124,18 @@ describe AppUserFinder, "#call" do
     expect(collab1.role).to eq(:collaborator)
   end
 
-  it 'fetches organization owners' do
+  it 'fetches team owners' do
     stub_heroku_api do
       get "/apps/:id" do |id|
         MultiJson.encode(
           name: "example",
           owner: {
             id:    SecureRandom.uuid,
-            email: "organization@herokumanager.com",
+            email: "team@herokumanager.com",
           })
       end
 
-      get "/organizations/:name/members" do
+      get "/teams/:name/members" do
         MultiJson.encode([
           {
             role: 'admin',
@@ -169,7 +169,7 @@ describe AppUserFinder, "#call" do
     expect(emails).to include('someone@example.com')
     expect(emails).to include('username2@example.com')
     expect(emails).not_to include('member@example.com')
-    expect(emails).not_to include('organization@herokumanager.com')
+    expect(emails).not_to include('team@herokumanager.com')
   end
 
   it "excludes users who have never logged in" do
@@ -209,18 +209,18 @@ describe AppUserFinder, "#call" do
     expect(response).to be_empty
   end
 
-  it "handles missing org lookups" do
+  it "handles missing team lookups" do
     stub_heroku_api do
       get "/apps/:id" do |id|
         MultiJson.encode(
           name: "example",
           owner: {
             id:    SecureRandom.uuid,
-            email: "organization@herokumanager.com",
+            email: "team@herokumanager.com",
           })
       end
 
-      get "/organizations/:name/members" do
+      get "/teams/:name/members" do
         raise Excon::Errors::NotFound, "not found"
       end
     end

--- a/spec/telex/heroku_client_spec.rb
+++ b/spec/telex/heroku_client_spec.rb
@@ -16,15 +16,15 @@ describe Telex::HerokuClient, '#new' do
 
   it 'handles requests' do
     client = Telex::HerokuClient.new
-    stub_request(:get, "#{client.uri}/organizations/foobar/members").
+    stub_request(:get, "#{client.uri}/teams/foobar/members").
       to_return(status: 200, body: [{'id' => 1}].to_json)
 
-    expect(client.organization_members('foobar')).to eql([{'id' => 1}])
+    expect(client.team_members('foobar')).to eql([{'id' => 1}])
   end
 
   it 'handles ranges' do
     client = Telex::HerokuClient.new
-    stub_request(:get, "#{client.uri}/organizations/foobar/members").
+    stub_request(:get, "#{client.uri}/teams/foobar/members").
       with(headers: {'Range'=>'id ..; max=1000;'}).
       to_return(
         status: 206,
@@ -34,19 +34,19 @@ describe Telex::HerokuClient, '#new' do
         }
       )
 
-      stub_request(:get, "#{client.uri}/organizations/foobar/members").
+      stub_request(:get, "#{client.uri}/teams/foobar/members").
         with(headers: {'Range'=>']1..; max=1000;'}).
         to_return(status: 206, body: [{'id' => 2}].to_json)
 
-    expect(client.organization_members('foobar')).to eql([{'id' => 1}, {'id' => 2}])
+    expect(client.team_members('foobar')).to eql([{'id' => 1}, {'id' => 2}])
   end
 
   it 'raises a NotFound error on 404s' do
     client = Telex::HerokuClient.new
-    stub_request(:get, "#{client.uri}/organizations/foobar/members").
+    stub_request(:get, "#{client.uri}/teams/foobar/members").
       to_return(status: 404)
 
-    expect { client.organization_members('foobar') }.
+    expect { client.team_members('foobar') }.
       to raise_error(Telex::HerokuClient::NotFound)
   end
 


### PR DESCRIPTION
Migrate Telex's use of `/organizations` API endpoint to `/teams`.

Depends on https://github.com/heroku/api/pull/7634