### PR TITLE
Properly Handle Errors on Endpoints

### DIFF
--- a/lib/endpoints/app_api/recipients.rb
+++ b/lib/endpoints/app_api/recipients.rb
@@ -10,6 +10,10 @@ module Endpoints
         @app_info = get_app_info
       end
 
+      error Excon::Errors::Unauthorized do
+        status 401
+      end
+
       error Excon::Errors::Forbidden do
         status 403
       end

--- a/lib/endpoints/app_api/recipients.rb
+++ b/lib/endpoints/app_api/recipients.rb
@@ -10,28 +10,6 @@ module Endpoints
         @app_info = get_app_info
       end
 
-      error Excon::Errors::Unauthorized do
-        status 401
-      end
-
-      error Excon::Errors::Forbidden do
-        status 403
-      end
-
-      error Mediators::Recipients::NotFound, Excon::Errors::NotFound, Pliny::Errors::NotFound do
-        status 404
-      end
-
-      error Mediators::Recipients::LimitError do
-        status 429
-        { "id": "bad_request", "message": sinatra_error.message }.to_json
-      end
-
-      error MultiJson::ParseError, Sequel::ValidationFailed, Sequel::UniqueConstraintViolation, Mediators::Recipients::BadRequest do
-        status 400
-        { "id": "bad_request", "message": bad_request_message }.to_json
-      end
-
       get "/recipients" do
         recipients = Mediators::Recipients::Lister.run(app_info: @app_info)
         respond_json(recipients)

--- a/lib/endpoints/app_api/recipients.rb
+++ b/lib/endpoints/app_api/recipients.rb
@@ -78,21 +78,6 @@ module Endpoints
       def get_app_info
         heroku_client.app_info(params[:app_id], base_headers_only: true)
       end
-
-      def sinatra_error
-        env['sinatra.error']
-      end
-
-      def bad_request_message
-        case sinatra_error
-        when MultiJson::ParseError
-          "Unable to parse the JSON request"
-        when Sequel::UniqueConstraintViolation
-          "A recipient with that email already exists"
-        when Sequel::ValidationFailed, Mediators::Recipients::BadRequest
-          sinatra_error.message
-        end
-      end
     end
   end
 end

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -24,8 +24,26 @@ module Endpoints
       also_reload "#{Config.root}/lib/**/*.rb"
     end
 
-    error Sinatra::NotFound do
-      raise Pliny::Errors::NotFound
+    error Excon::Errors::Unauthorized do
+      status 401
+    end
+
+    error Excon::Errors::Forbidden do
+      status 403
+    end
+
+    error Sinatra::NotFound, Mediators::Recipients::NotFound, Excon::Errors::NotFound, Pliny::Errors::NotFound do
+      status 404
+    end
+
+    error Mediators::Recipients::LimitError do
+      status 429
+      { "id": "bad_request", "message": sinatra_error.message }.to_json
+    end
+
+    error MultiJson::ParseError, Sequel::ValidationFailed, Sequel::UniqueConstraintViolation, Mediators::Recipients::BadRequest do
+      status 400
+      { "id": "bad_request", "message": bad_request_message }.to_json
     end
   end
 end

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -38,7 +38,7 @@ module Endpoints
 
     error Mediators::Recipients::LimitError do
       status 429
-      { "id": "bad_request", "message": sinatra_error.message }.to_json
+      { "id": "rate_limit_reached", "message": sinatra_error.message }.to_json
     end
 
     error MultiJson::ParseError, Sequel::ValidationFailed, Sequel::UniqueConstraintViolation, Mediators::Recipients::BadRequest do

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -45,5 +45,22 @@ module Endpoints
       status 400
       { "id": "bad_request", "message": bad_request_message }.to_json
     end
+
+    private
+
+    def sinatra_error
+      env['sinatra.error']
+    end
+
+    def bad_request_message
+      case sinatra_error
+      when MultiJson::ParseError
+        "Unable to parse the JSON request"
+      when Sequel::UniqueConstraintViolation
+        "A recipient with that email already exists"
+      when Sequel::ValidationFailed, Mediators::Recipients::BadRequest
+        sinatra_error.message
+      end
+    end
   end
 end

--- a/lib/initializer.rb
+++ b/lib/initializer.rb
@@ -17,10 +17,10 @@ module Initializer
       lib/telex/**/*
       lib/serializers/base
       lib/serializers/**/*
-      lib/endpoints/base
-      lib/endpoints/**/*
       lib/mediators/base
       lib/mediators/**/*
+      lib/endpoints/base
+      lib/endpoints/**/*
       lib/middleware/**/*
       lib/routes
       lib/jobs/**/*


### PR DESCRIPTION
Extracts the error handling in the endpoint base class so we don't leak these to Rollbar.
Also catches 401s from API to prevent:
https://rollbar.com/Heroku-3/telex/items/177/