### PR TITLE
Send request id with all heroku client requests

### DIFF
--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -67,9 +67,10 @@ module Telex
       range = "id ..; max=1000;" if range.nil?
 
       base = {
-        "Accept"     => "application/vnd.heroku+json; version=3#{variant}",
-        "User-Agent" => "telex",
-        "Range"      => range,
+        "Accept"             => "application/vnd.heroku+json; version=3#{variant}",
+        "User-Agent"         => "telex",
+        "X-Heroku-Requester" => "Telex",
+        "Range"              => range
       }
 
       request_id = Pliny::RequestStore.store[:request_id]

--- a/lib/telex/heroku_client.rb
+++ b/lib/telex/heroku_client.rb
@@ -69,8 +69,11 @@ module Telex
       base = {
         "Accept"     => "application/vnd.heroku+json; version=3#{variant}",
         "User-Agent" => "telex",
-        "Range"      => range
+        "Range"      => range,
       }
+
+      request_id = Pliny::RequestStore.store[:request_id]
+      base["Request-Id"] = request_id if request_id
 
       if base_headers_only
         base

--- a/spec/telex/heroku_client_spec.rb
+++ b/spec/telex/heroku_client_spec.rb
@@ -14,7 +14,7 @@ describe Telex::HerokuClient, '#new' do
     expect(uri.password).to eq(key)
   end
 
-  it 'handles requests' do
+  it 'passes the current request-id' do
     Pliny::RequestStore.store[:request_id] = '12345'
     client = Telex::HerokuClient.new
     stub_request(:get, "#{client.uri}/teams/foobar/members").
@@ -24,7 +24,7 @@ describe Telex::HerokuClient, '#new' do
     expect(client.team_members('foobar')).to eql([{'id' => 1}])
   end
 
-  it 'passes the current request-id' do
+  it 'handles requests' do
     client = Telex::HerokuClient.new
     stub_request(:get, "#{client.uri}/teams/foobar/members").
       to_return(status: 200, body: [{'id' => 1}].to_json)

--- a/spec/telex/heroku_client_spec.rb
+++ b/spec/telex/heroku_client_spec.rb
@@ -15,6 +15,16 @@ describe Telex::HerokuClient, '#new' do
   end
 
   it 'handles requests' do
+    Pliny::RequestStore.store[:request_id] = '12345'
+    client = Telex::HerokuClient.new
+    stub_request(:get, "#{client.uri}/teams/foobar/members").
+      with(headers: {'Request-Id'=>'12345'}).
+      to_return(status: 200, body: [{'id' => 1}].to_json)
+
+    expect(client.team_members('foobar')).to eql([{'id' => 1}])
+  end
+
+  it 'passes the current request-id' do
     client = Telex::HerokuClient.new
     stub_request(:get, "#{client.uri}/teams/foobar/members").
       to_return(status: 200, body: [{'id' => 1}].to_json)


### PR DESCRIPTION
This will help in tracking down issues like https://github.com/heroku/core-services/issues/31
Also adds the `X-Heroku-Requester` header.