### PR TITLE
Use Pliny Errors to Handle Expected Failure Cases

### DIFF
--- a/lib/endpoints/health.rb
+++ b/lib/endpoints/health.rb
@@ -16,7 +16,7 @@ module Endpoints
 
     def check_api_key
       Telex::HerokuClient.new.account_info
-    rescue Excon::Errors::Unauthorized, Excon::Errors::Forbidden
+    rescue Pliny::Errors::Unauthorized, Pliny::Errors::Forbidden
       # our API key is bad! fail the health check so we get alerted:
       halt 503
     rescue Excon::Errors::Error

--- a/spec/endpoints/app_api/recipients_spec.rb
+++ b/spec/endpoints/app_api/recipients_spec.rb
@@ -12,6 +12,13 @@ describe Endpoints::AppAPI::Recipients do
     HerokuApiStub::APP_ID
   end
 
+  def app
+    Rack::Builder.new do
+      use Pliny::Middleware::RescueErrors
+      run Endpoints::AppAPI::Recipients
+    end
+  end
+
   before do
     stub_heroku_api
     Pliny::RequestStore.store[:heroku_client] = heroku_client
@@ -140,7 +147,7 @@ describe Endpoints::AppAPI::Recipients do
       delete "/#{app_id}/recipients/#{recipient.id}"
       expect(last_response.status).to eq(404)
     end
-    
+
     it "allows creation of the same email once deleted" do
       recipient = Fabricate(:recipient, app_id: app_id)
 

--- a/spec/telex/heroku_client_spec.rb
+++ b/spec/telex/heroku_client_spec.rb
@@ -112,5 +112,26 @@ describe Telex::HerokuClient, '#new' do
           to raise_error(Telex::HerokuClient::BadResponse)
       end
     end
+
+    it 'throws unauthorized on a 401 response' do
+      client = Telex::HerokuClient.new
+
+      stub_request(:put, "#{client.uri}/users/~/capabilities")
+        .to_return(:status => 401, :body => "", :headers => {})
+
+      expect { client.capable?(type: "app", id: "123", capability: "view_metrics") }.
+        to raise_error(Pliny::Errors::Unauthorized)
+    end
+
+    it 'throws forbidden on a 403 response' do
+      client = Telex::HerokuClient.new
+
+      stub_request(:put, "#{client.uri}/users/~/capabilities")
+        .to_return(:status => 403, :body => "", :headers => {})
+
+      expect { client.capable?(type: "app", id: "123", capability: "view_metrics") }.
+        to raise_error(Pliny::Errors::Forbidden)
+    end
+
   end
 end


### PR DESCRIPTION
Just doing `status 404` means the errors still show up in Rollbar.