### PR TITLE
Ignore Pliny Errors in Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -12,7 +12,8 @@ unless Config.rack_env == 'test'
     config.scrub_headers |= Rollbar::Blanket.headers
 
     config.exception_level_filters.merge!(
-      'Telex::Emailer::DeliveryError' => 'warning'
+      "Telex::Emailer::DeliveryError" => "warning",
+      "Pliny::Errors::HTTPStatusError" => "ignore"
     )
   end
 end


### PR DESCRIPTION
For some reason I thought Pliny already takes care of this, but that's not the case...