### PR TITLE
No longer use Rollbar Middleware

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -5,7 +5,7 @@ unless Config.rack_env == 'test'
     config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
     config.logger = Pliny::RollbarLogger.new
     config.use_sucker_punch
-    config.disable_monkey_patch = true
+    config.disable_rack_monkey_patch = true
     config.root = Config.root
 
     config.scrub_fields  |= Rollbar::Blanket.fields

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,7 +1,6 @@
 require "rollbar/middleware/sinatra"
 
 Routes = Rack::Builder.new do
-  use Rollbar::Middleware::Sinatra
   use Pliny::Middleware::RequestStore::Clear
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
@@ -9,11 +8,15 @@ Routes = Rack::Builder.new do
   use Middleware::Instrumentation
   use Pliny::Middleware::RequestStore::Seed, store: Pliny::RequestStore
   use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
-  use Rack::Timeout,
-      service_timeout: Config.timeout if Config.timeout > 0
-  use Pliny::Middleware::Versioning,
-      default: Config.versioning_default,
-      app_name: Config.versioning_app_name if Config.versioning?
+  if Config.timeout > 0
+    use Rack::Timeout,
+        service_timeout: Config.timeout
+  end
+  if Config.versioning?
+    use Pliny::Middleware::Versioning,
+        default: Config.versioning_default,
+        app_name: Config.versioning_app_name
+  end
   use Rack::Deflater
 
   use Rack::ConditionalGet


### PR DESCRIPTION
This is handled by `Pliny::Middleware::RescueErrors` now, see https://github.com/interagent/pliny/pull/265