### PR TITLE
Enable table support

### DIFF
--- a/lib/telex/emailer.rb
+++ b/lib/telex/emailer.rb
@@ -69,6 +69,7 @@ class Telex::Emailer
   def generate_html
     markdown = Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(filter_html: true),
+      tables: true,
       no_intra_emphasis: true,
       autolink: true
     )

--- a/spec/telex/emailer.md
+++ b/spec/telex/emailer.md
@@ -1,0 +1,5 @@
+## Table Test
+| Domain | Reason |
+| :---: | :---: |
+| www.test1.com | failure reason 1 |
+| www.test3.com |

--- a/spec/telex/emailer.md
+++ b/spec/telex/emailer.md
@@ -1,5 +1,5 @@
 ## Table Test
 | Domain | Reason |
-| :---: | :---: |
+| :--------------------: | :--------------------: |
 | www.test1.com | failure reason 1 |
 | www.test3.com |

--- a/spec/telex/emailer_spec.rb
+++ b/spec/telex/emailer_spec.rb
@@ -48,7 +48,13 @@ describe Telex::Emailer do
       options.merge(body: body)
     )
 
-    expected_body = "<h2>Table Test</h2>\n\n" +
+    expected_plaintext_body =  "## Table Test\n" +
+                               "| Domain | Reason |\n" +
+                               "| :--------------------: | :--------------------: |\n" +
+                               "| www.test1.com | failure reason 1 |\n" +
+                               "| www.test3.com |\n"
+
+    expected_html_body = "<h2>Table Test</h2>\n\n" +
                     "<table><thead>\n" +
                     "<tr>\n" +
                     "<th style=\"text-align: center\">Domain</th>\n" +
@@ -66,7 +72,8 @@ describe Telex::Emailer do
                     "</tbody></table>\n"
 
     mail = emailer.deliver!
-    expect(mail.html_part.body).to include(expected_body)
+    expect(mail.text_part.body).to include(expected_plaintext_body)
+    expect(mail.html_part.body).to include(expected_html_body)
   end
 
   # see https://developers.google.com/gmail/markup/actions/actions-overview

--- a/spec/telex/emailer_spec.rb
+++ b/spec/telex/emailer_spec.rb
@@ -42,6 +42,33 @@ describe Telex::Emailer do
     end
   end
 
+  it 'transforms a markdown table to an HTML table' do
+    body = File.read("./spec/telex/emailer.md")
+    emailer = Telex::Emailer.new(
+      options.merge(body: body)
+    )
+
+    expected_body = "<h2>Table Test</h2>\n\n" +
+                    "<table><thead>\n" +
+                    "<tr>\n" +
+                    "<th style=\"text-align: center\">Domain</th>\n" +
+                    "<th style=\"text-align: center\">Reason</th>\n" +
+                    "</tr>\n" +
+                    "</thead><tbody>\n" +
+                    "<tr>\n" +
+                    "<td style=\"text-align: center\"><a href=\"http://www.test1.com\">www.test1.com</a></td>\n" +
+                    "<td style=\"text-align: center\">failure reason 1</td>\n" +
+                    "</tr>\n" +
+                    "<tr>\n" +
+                    "<td style=\"text-align: center\"><a href=\"http://www.test3.com\">www.test3.com</a></td>\n" +
+                    "<td style=\"text-align: center\"></td>\n" +
+                    "</tr>\n" +
+                    "</tbody></table>\n"
+
+    mail = emailer.deliver!
+    expect(mail.html_part.body).to include(expected_body)
+  end
+
   # see https://developers.google.com/gmail/markup/actions/actions-overview
   describe 'ld+json support for action shortcuts in GMail' do
     before do


### PR DESCRIPTION
I'm currently working on an update to ACM that involves sending email that contains tabular data within the body of the email. I can definitely build the email based on a .markdown template, but I need table support turned on in Telex in order for the email to be rendered properly.

This change enables the use of markdown tables in the body of an email.