### PR TITLE
Add console process type

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec puma --config config/puma.rb config.ru
 worker: bundle exec sidekiq -g ${DYNO:-default} -i ${DYNO:-1} -r ./lib/application.rb
 clock: bundle exec clockwork lib/clock.rb
+console: bin/console


### PR DESCRIPTION
This PR makes sure that proper console is launched when `heroku run console` is executed on telex app. Currently it runs default ruby buldpack's irb.