### PR TITLE
Allow followups to be sent from a different producer

### DIFF
--- a/lib/endpoints/producer_api/messages.rb
+++ b/lib/endpoints/producer_api/messages.rb
@@ -29,7 +29,7 @@ module Endpoints
       post '/:message_id/followups' do
         redis_retry do
           begin
-            message = Message[id: params['message_id'], producer_id: current_producer.id]
+            message = Message[id: params['message_id']]
             raise Pliny::Errors::NotFound unless message
 
             followup = Mediators::Followups::Creator.run(

--- a/spec/endpoints/producer_api/messages_spec.rb
+++ b/spec/endpoints/producer_api/messages_spec.rb
@@ -90,6 +90,13 @@ describe Endpoints::ProducerAPI::Messages do
         expect(last_response.status).to eq(201)
       end
 
+      it "succeeds when the message belongs to a different producer" do
+        @message.producer = Fabricate(:producer)
+        @message.save
+        do_post
+        expect(last_response.status).to eq(201)
+      end
+
       it 'creates a followup' do
         expect(Followup.where(message_id: @message.id).count).to eq(0)
         do_post
@@ -124,13 +131,6 @@ describe Endpoints::ProducerAPI::Messages do
 
       it "fails with a missing message_id" do
         @message.id = SecureRandom.uuid
-        do_post
-        expect(last_response.status).to eq(404)
-      end
-
-      it "fails when the message belongs to a different producer" do
-        @message.producer = Fabricate(:producer)
-        @message.save
         do_post
         expect(last_response.status).to eq(404)
       end


### PR DESCRIPTION
While Performing a credroll, we create a new producer rather changing than the api key for the current Producer. This leads to a problem when the old producer is deprecated, we can no longer send followups to the messages that were created with the old producer. 

https://trello.com/c/oki213Hk/1003-telex-supports-no-downtime-producer-credrolls