### PR TITLE
Send from notifications.heroku.com domain instead

### DIFF
--- a/lib/telex/emailer.rb
+++ b/lib/telex/emailer.rb
@@ -22,7 +22,7 @@ class Telex::Emailer
   def deliver!
     mail = Mail.new
     mail.to      = email
-    mail.from    = from || 'Heroku Notifications <bot@heroku.com>'
+    mail.from    = from || 'Heroku Notifications <bot@notifications.heroku.com>'
     mail.subject = subject
     if notification_id
       mail.message_id = "<#{notification_id}@notifications.heroku.com>"

--- a/spec/telex/emailer_spec.rb
+++ b/spec/telex/emailer_spec.rb
@@ -7,7 +7,7 @@ describe Telex::Emailer do
 
   it 'sets from' do
     mail = emailer.deliver!
-    expect(mail.from).to eq(%w( bot@heroku.com ))
+    expect(mail.from).to eq(%w( bot@notifications.heroku.com ))
   end
 
   it 'sets a custom from' do


### PR DESCRIPTION
Trello card: https://trello.com/c/zqFmaN6P/827-e-mail-reputation-isolation-move-telex-onto-its-own-domain-and-dedicated-ip-in-mailgun

We'll also want to update `MAILGUN_SMTP_LOGIN` and `MAILGUN_SMTP_PASSWORD` to be the login/password for https://app.mailgun.com/app/domains/notifications.heroku.com.