### PR TITLE
notifications creator: enable dashboard type

### DIFF
--- a/lib/mediators/notifications/creator.rb
+++ b/lib/mediators/notifications/creator.rb
@@ -7,9 +7,7 @@ module Mediators::Notifications
 
     def call
       self.notification = Notification.create(notifiable: notifiable, message_id: message.id)
-      # One possibility. Just jotting down notes
-      # send_email unless message.target_type == Message::DASHBOARD
-      send_email
+      send_email unless message.target_type == Message::DASHBOARD
       notification
     rescue Sequel::ValidationFailed, Sequel::UniqueConstraintViolation
       # Notification already queued, just ignore.

--- a/spec/mediators/notifications/creator_spec.rb
+++ b/spec/mediators/notifications/creator_spec.rb
@@ -27,4 +27,12 @@ describe Mediators::Notifications::Creator do
     expect(Mail::TestMailer.deliveries.count).to be(0)
     expect(Notification.count).to be(0)
   end
+
+  it 'does not send an email when type=dashboard' do
+    @creator.send(:message).target_type = Message::DASHBOARD
+    result = nil
+    expect{ result = @creator.call }.to change(Notification, :count).by(1)
+    expect(result).to be_instance_of(Notification)
+    expect(Mail::TestMailer.deliveries.count).to be(0)
+  end
 end


### PR DESCRIPTION
## Context

A while ago, when opex was thinking about all the types of
notifications, we thought having `TYPE=dashboard` would be useful.

The goal of `TYPE=dashboard` is to create a notification, without sending
an email, and that would purely be visible in the notifications tab.

## Why now?

SDDTLS (spaces-default-domain-tls) was recently launched. When you
create a private space app, we automatically provision a letsencrypt
TLS certificate. It would be great if we can create a notification as soon
as the cert is created, and uploaded to the app successfully -- without
sending an email.

## Metadata

Connects to https://github.com/heroku/runtime/issues/2730