### PR TITLE
Add dashboard type to message_target pq type

### DIFF
--- a/db/migrate/1543529321_add_dashboard_to_message_type.rb
+++ b/db/migrate/1543529321_add_dashboard_to_message_type.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  no_transaction
+  change do
+    execute <<-SQL
+      ALTER TYPE message_target ADD VALUE 'dashboard';
+    SQL
+  end
+end


### PR DESCRIPTION
This makes the `target_type=dashboard` not throw a 422, since pq will complain with the following otherwise:

```
Sequel::DatabaseError: PG::InvalidTextRepresentation: ERROR:  invalid input value for enum message_target: "dashboard"
LINE 1: ...3b4f47b516', 'my message', 'my body', NULL, NULL, 'dashboard...
```