### PR TITLE
add /user/notifications/unread-count endpoint

### DIFF
--- a/db/migrate/1566411434293_notifications_read_at_null_index.rb
+++ b/db/migrate/1566411434293_notifications_read_at_null_index.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  no_transaction
+  change do
+    alter_table(:notifications) do
+      add_index :user_id, name: "notifications_user_id_null_read_at", where: {read_at: nil}, concurrently: true
+    end
+  end
+end

--- a/lib/endpoints/user_api/notifications.rb
+++ b/lib/endpoints/user_api/notifications.rb
@@ -19,6 +19,13 @@ module Endpoints
         end
       end
 
+      get '/unread-count' do
+        redis_retry do
+          unread_count = Mediators::Notifications::UnreadCounter.run(user: current_user)
+          encode({unread_count: unread_count})
+        end
+      end
+
       get '/:id/read.png' do |id|
         note = ::Notification[id: id]
         raise Pliny::Errors::NotFound unless note

--- a/lib/mediators/notifications/unread_counter.rb
+++ b/lib/mediators/notifications/unread_counter.rb
@@ -1,0 +1,15 @@
+module Mediators::Notifications
+  class UnreadCounter < Mediators::Base
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      Notification
+        .where(user: @user)
+        .where(Sequel.lit("notifications.created_at > now() - '1 month'::interval"))
+        .where(Sequel.lit("notifications.read_at IS NULL"))
+        .count
+    end
+  end
+end


### PR DESCRIPTION
Most users do not look at their notifications. It is therefore a bit
wasteful of their bandwidth and loading time to load data they're not
necessarily going to look at. The `/user/notifications/unread-count`
does a `COUNT` for the unread notifications for the user, which saves
bandwidth and processing time as they don't have to download the entire
body of the messges. The ruby app should also have to do less work and
not have to encode the body for the JSON messages unless the user is
actively looking at their messages. The database query should be less expensive as we don't need to do an `eager_graph` for the messages table.

For example, for me, a user in a large enterprise account, it currently takes ~15s and I have to download 7.3MB of JSON, blocking the rest of the rendering in Dashboard.

<img width="1206" alt="Screen_Shot_2019-07-22_at_8_20_23_AM" src="https://user-images.githubusercontent.com/1275021/61644855-57b49f80-ac5a-11e9-83a7-db2acacfe460.png">


(I know the screenshot says "particleboard", but we really only use particleboard to proxy to telex and render the markdown for each message. I saw a similar message hitting telex.heroku.com/user/notifications directly)

Questions for review:

* Do we need any indexes or other modifications to make this query fast?