### PR TITLE
specify postgres in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,14 @@ before_script:
 script: bundle exec rspec
 bundler_args: --local
 services:
+  - postgresql
   - redis-server
+addons:
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
 env:
 rvm:
   - 2.6.2


### PR DESCRIPTION
This fixes PRs and master. It seems like we need to start specifying that the postgres service start in .travis.yml?