### PR TITLE
allow sql statement logging

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -24,6 +24,7 @@ module Config
   optional :console_banner
   optional :versioning_app_name
   optional :versioning_default
+  optional :database_log_level
 
   # Override -- value is returned or the set default
   override :cache_user_auth,  true,  bool

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -8,3 +8,9 @@ end
 DB = Sequel.connect(Config.database_url,
                     max_connections: Config.db_pool,
                     after_connect: database_setup_proc)
+
+if Config.database_log_level
+  DB.loggers << Logger.new(STDOUT)
+  DB.log_connection_info = true
+  DB.sql_log_level = Config.database_log_level
+end

--- a/config/initializers/database.rb
+++ b/config/initializers/database.rb
@@ -10,7 +10,7 @@ DB = Sequel.connect(Config.database_url,
                     after_connect: database_setup_proc)
 
 if Config.database_log_level
-  DB.loggers << Logger.new(STDOUT)
+  DB.loggers << Logger.new(Pliny.stdout || $stdout)
   DB.log_connection_info = true
   DB.sql_log_level = Config.database_log_level
 end


### PR DESCRIPTION
This is a nice to have debugging feature in general for
database backed applications.

You enable sql statement logging by setting `DATABASE_LOG_LEVEL`
environment variable to the desired level (eg. `info`, `warn`, `debug`),
note that `info` is the only level that will log _all_ statements.