### PR TITLE
log the class name on error

### DIFF
--- a/lib/mediators/notifications/creator.rb
+++ b/lib/mediators/notifications/creator.rb
@@ -11,7 +11,7 @@ module Mediators::Notifications
       notification
     rescue Sequel::ValidationFailed, Sequel::UniqueConstraintViolation
       # Notification already queued, just ignore.
-      Pliny.log(duplicate_notificaiton: true, notifiable_id: notifiable.id, notifiable_type: notifiable.class, message_id: message.id)
+      Pliny.log(duplicate_notificaiton: true, notifiable_id: notifiable.id, notifiable_type: notifiable.class.name, message_id: message.id)
     rescue => e
       # ^ Typically an email send failure.
       # Remove the notification before we re-raise so the mediator can be run


### PR DESCRIPTION
the pliny log scrubber can do fun things with the params passed to
`Pliny.log`. For example, if you pass it a `Sequel` class, the scrubber
could attempt to call various methods. In particular, it might inquire
if the class responds to `to_hash` and if so it might call `to_hash`...
and `User.to_hash` yields `SELECT * FROM "users"` which is bad news for
performance...