### PR TITLE
Don't send follow up notifications to newly removed collabs

### DIFF
--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -12,24 +12,24 @@ module Mediators::Followups
 
     private
 
-    # if any collaborators who received the original message are still collabs, send it to just that list minus 
-    # anyone who was removed as a collab. Otherwise, send it to all current collabs. 
+    # if any collaborators who received the original message are still collabs, send it to just that list minus
+    # anyone who was removed as a collab. Otherwise, send it to all current collabs.
     # Sometimes a user may not exist in telex yet, so have to create them.
     def update_notifications
-      if notifications_for_collabs_that_recieved_original_message.any?
-        notifications_for_collabs_that_recieved_original_message
+      if original_message_recipient_notifications.any?
+        original_message_recipient_notifications
       else
-        create_notifications_for_new_collabs
+        create_notifications_for_all_collabs
       end
     end
 
-    def notifications_for_collabs_that_recieved_original_message
+    def original_message_recipient_notifications
       message.notifications.select do |n|
         current_collab_hids.include?(n.user.heroku_id)
       end
     end
 
-    def create_notifications_for_new_collabs
+    def create_notifications_for_all_collabs
       notifiable_hids = message.notifications.map {|n| n.user.heroku_id }
       new_notifiables = []
 

--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -12,9 +12,9 @@ module Mediators::Followups
 
     private
 
-    # if there exists collaborators who received the original message, send it to them.
-    # otherwise, send it to all collabs. Sometimes this user may not exist in telex yet,
-    # so we have to create them.
+    # if any collaborators who received the original message are still collabs, send it to just that list minus 
+    # anyone who was removed as a collab. Otherwise, send it to all current collabs. 
+    # Sometimes a user may not exist in telex yet, so have to create them.
     def update_notifications
       if notifications_for_collabs_that_recieved_original_message.any?
         notifications_for_collabs_that_recieved_original_message

--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -1,0 +1,60 @@
+module Mediators::Followups
+  class NotificationUpdater < Mediators::Base
+    attr_accessor :message
+
+    def initialize(followup:)
+      self.message = followup.message
+    end
+
+    def call
+      update_notifications
+    end
+
+    private
+
+    # if there exists collaborators who received the original message, send it to them.
+    # otherwise, send it to all collabs. Sometimes this user may not exist in telex yet,
+    # so we have to create them.
+    def update_notifications
+      if notifications_for_collabs_that_recieved_original_message.any?
+        notifications_for_collabs_that_recieved_original_message
+      else
+        create_notifications_for_new_collabs
+      end
+    end
+
+    def notifications_for_collabs_that_recieved_original_message
+      message.notifications.select do |n|
+        current_collab_hids.include?(n.user.heroku_id)
+      end
+    end
+
+    def create_notifications_for_new_collabs
+      notifiable_hids = message.notifications.map {|n| n.user.heroku_id }
+      new_notifiables = []
+
+      current_collabs.each do |c|
+        if !notifiable_hids.include?(c["user"]["id"])
+          # not using the notification mediator here because it sends an email,
+          # which we also do in this mediator
+          user = find_or_create_user(c["user"]["id"], c["user"]["email"])
+          new_notifiables << Notification.create(notifiable: user, message_id: message.id)
+        end
+      end
+
+      new_notifiables
+    end
+
+    def find_or_create_user(heroku_id, email)
+      User[heroku_id: heroku_id] || User.create(heroku_id: heroku_id, email: email)
+    end
+
+    def current_collab_hids
+      current_collabs.map {|c| c["user"]["id"] }
+    end
+
+    def current_collabs
+      @current_collabs ||= Telex::HerokuClient.new.app_collaborators(message.target_id)
+    end
+  end
+end

--- a/lib/mediators/followups/notifier.rb
+++ b/lib/mediators/followups/notifier.rb
@@ -1,10 +1,12 @@
 module Mediators::Followups
   class Notifier < Mediators::Base
     attr_accessor :followup, :message, :notifications
-    def initialize(followup: )
+    def initialize(followup:)
       self.followup = followup
       self.message = followup.message
-      self.notifications = filter_notifications
+      self.notifications = Mediators::Followups::NotificationUpdater.run(
+        followup: followup
+      )
     end
 
     def call
@@ -13,20 +15,6 @@ module Mediators::Followups
     end
 
     private
-
-    def heroku_client
-      @client ||= Telex::HerokuClient.new
-    end
-
-    def filter_notifications
-      current_collabs_ids = heroku_client.app_collaborators(message.target_id).map do |c|
-        c["user"]["id"]
-      end
-
-      message.notifications.select do |n|
-        current_collabs_ids.include?(n.user.heroku_id)
-      end
-    end
 
     def update_users
       notifications.each do |note|

--- a/lib/mediators/messages/user_user_finder.rb
+++ b/lib/mediators/messages/user_user_finder.rb
@@ -3,6 +3,7 @@ require_relative './user_finder'
 module Mediators::Messages
   class UserUserFinder < UserFinder
     private
+
     def get_notifiables
       user_response = heroku_client.account_info(user_uuid: target_id)
 

--- a/spec/mediators/followups/notification_updater_spec.rb
+++ b/spec/mediators/followups/notification_updater_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Mediators::Followups::NotificationUpdater do
+  include HerokuAPIMock
+
+  before do
+    @user1, @user2 = create_heroku_user, create_heroku_user
+    @note1, @note2 = [@user1, @user2].map { |u| double("notification", id: SecureRandom.uuid, user: u) }
+    @heroku_app = create_heroku_app(owner: @user1, collaborators: [@user1, @user2])
+  end
+
+  it "returns notifications from collabs who received the original message" do
+    message = double("message",
+      title: Faker::Company.bs,
+      id: SecureRandom.uuid,
+      notifications: [@note1, @note2],
+      target_id: @heroku_app.id)
+    followup = double("followup", body: Faker::Company.bs, message: message)
+    notifications = described_class.run(followup: followup)
+
+    expect(notifications).to contain_exactly(@note1, @note2)
+  end
+
+  it "creates and returns notifications for all collabs if none received the original message" do
+    message = Fabricate(:message,
+      title: Faker::Company.bs,
+      notifications: [Fabricate(:notification)],
+      target_id: @heroku_app.id)
+
+    followup = double("followup", body: Faker::Company.bs, message: message)
+    user3, user4 = Fabricate(:user), Fabricate(:user)
+
+    update_app_collaborators(@heroku_app, [user3, user4])
+    notifications = described_class.run(followup: followup)
+    expected = notifications.map(&:user)
+
+    expect(expected).to contain_exactly(user3, user4)
+  end
+end

--- a/spec/mediators/followups/notifier_spec.rb
+++ b/spec/mediators/followups/notifier_spec.rb
@@ -30,4 +30,13 @@ RSpec.describe Mediators::Followups::Notifier do
     expect(ds.map(&:subject).uniq).to eq([@message.title])
     expect(ds.map(&:in_reply_to).uniq.sort).to eq(["#{@note1.id}@notifications.heroku.com", "#{@note2.id}@notifications.heroku.com"].sort)
   end
+
+  it "does not notify users that have been removed as collabs" do
+    update_app_collaborators(@heroku_app, [@user1])
+    @notifier = described_class.new(followup: @followup)
+    expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user1.heroku_id)
+    expect(Mediators::Messages::UserUserFinder).to_not receive(:run).with(target_id: @user2.heroku_id)
+
+    @notifier.call
+  end
 end

--- a/spec/mediators/followups/notifier_spec.rb
+++ b/spec/mediators/followups/notifier_spec.rb
@@ -1,42 +1,65 @@
 RSpec.describe Mediators::Followups::Notifier do
-  include HerokuAPIMock
+include HerokuAPIMock
 
-  before do
-    @user1, @user2 = create_heroku_user, create_heroku_user
-    @note1, @note2 = [@user1, @user2].map { |u| double("notification", id: SecureRandom.uuid, user: u) }
-    @heroku_app = create_heroku_app(owner: @user1, collaborators: [@user1, @user2])
-    @message = double("message",
+before do
+  @user1, @user2 = create_heroku_user, create_heroku_user
+  @note1, @note2 = [@user1, @user2].map { |u| double("notification", id: SecureRandom.uuid, user: u) }
+  @heroku_app = create_heroku_app(owner: @user1, collaborators: [@user1, @user2])
+  @message = double("message",
+    title: Faker::Company.bs,
+    id: SecureRandom.uuid,
+    notifications: [@note1, @note2],
+    target_id: @heroku_app.id)
+  @followup = double("followup", body: Faker::Company.bs, message: @message)
+  @notifier = described_class.new(followup: @followup)
+end
+
+it "uses the user finder update the users in case their emails have changed" do
+  expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user1.heroku_id)
+  expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user2.heroku_id)
+
+  @notifier.call
+end
+
+it "emails the users with the new followup" do
+  @notifier.call
+  ds = Mail::TestMailer.deliveries
+
+  expect(ds.size).to eq(2)
+  expect(ds.map(&:to).flatten.sort).to eq([@user1, @user2].map(&:email).sort)
+  expect(ds.map(&:subject).uniq).to eq([@message.title])
+  expect(ds.map(&:in_reply_to).uniq.sort).to eq(["#{@note1.id}@notifications.heroku.com", "#{@note2.id}@notifications.heroku.com"].sort)
+end
+
+it "does not notify users that have been removed as collabs" do
+  update_app_collaborators(@heroku_app, [@user1])
+  described_class.new(followup: @followup).call
+
+  ds = Mail::TestMailer.deliveries
+  expect(ds.size).to eq(1)
+  expect(ds.map(&:to).flatten.sort).to eq([@user1].map(&:email).sort)
+  expect(ds.map(&:subject).uniq).to eq([@message.title])
+  expect(ds.map(&:in_reply_to).uniq.sort).to eq(["#{@note1.id}@notifications.heroku.com"])
+end
+
+describe "when all existing collabs who were notified have been removed" do
+  it "notifies all new collabs" do
+    user1, user2 = create_heroku_user, create_heroku_user
+    heroku_app = create_heroku_app(owner: user1, collaborators: [user1, user2])
+    message = Fabricate(:message,
       title: Faker::Company.bs,
       id: SecureRandom.uuid,
-      notifications: [@note1, @note2],
-      target_id: @heroku_app.id)
-    @followup = double("followup", body: Faker::Company.bs, message: @message)
-    @notifier = described_class.new(followup: @followup)
-  end
+      target_id: heroku_app.id)
+    followup = double("followup", body: Faker::Company.bs, message: message)
 
-  it "uses the user finder update the users in case their emails have changed" do
-    expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user1.heroku_id)
-    expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user2.heroku_id)
+    user3 = create_heroku_user
+    update_app_collaborators(heroku_app, [user3])
+    described_class.new(followup: followup).call
 
-    @notifier.call
-  end
-
-  it "emails the users with the new followup" do
-    @notifier.call
     ds = Mail::TestMailer.deliveries
-
-    expect(ds.size).to eq(2)
-    expect(ds.map(&:to).flatten.sort).to eq([@user1, @user2].map(&:email).sort)
-    expect(ds.map(&:subject).uniq).to eq([@message.title])
-    expect(ds.map(&:in_reply_to).uniq.sort).to eq(["#{@note1.id}@notifications.heroku.com", "#{@note2.id}@notifications.heroku.com"].sort)
-  end
-
-  it "does not notify users that have been removed as collabs" do
-    update_app_collaborators(@heroku_app, [@user1])
-    @notifier = described_class.new(followup: @followup)
-    expect(Mediators::Messages::UserUserFinder).to receive(:run).with(target_id: @user1.heroku_id)
-    expect(Mediators::Messages::UserUserFinder).to_not receive(:run).with(target_id: @user2.heroku_id)
-
-    @notifier.call
+    expect(ds.size).to eq(1)
+    expect(ds.map(&:to).flatten.sort).to eq([user3].map(&:email).sort)
+    expect(ds.map(&:in_reply_to).uniq.sort).to eq(["#{Notification.first.id}@notifications.heroku.com"])
+    end
   end
 end

--- a/spec/mediators/followups/notifier_spec.rb
+++ b/spec/mediators/followups/notifier_spec.rb
@@ -1,10 +1,15 @@
 RSpec.describe Mediators::Followups::Notifier do
-  before do
-    allow(Mediators::Messages::UserUserFinder).to receive(:run)
+  include HerokuAPIMock
 
-    @user1, @user2 = 2.times.map { double("user", heroku_id: SecureRandom.uuid, email: Faker::Internet.email) }
+  before do
+    @user1, @user2 = create_heroku_user, create_heroku_user
     @note1, @note2 = [@user1, @user2].map { |u| double("notification", id: SecureRandom.uuid, user: u) }
-    @message = double("message", title: Faker::Company.bs, id: SecureRandom.uuid, notifications: [@note1, @note2])
+    @heroku_app = create_heroku_app(owner: @user1, collaborators: [@user1, @user2])
+    @message = double("message",
+      title: Faker::Company.bs,
+      id: SecureRandom.uuid,
+      notifications: [@note1, @note2],
+      target_id: @heroku_app.id)
     @followup = double("followup", body: Faker::Company.bs, message: @message)
     @notifier = described_class.new(followup: @followup)
   end

--- a/spec/support/mock_heroku_api.rb
+++ b/spec/support/mock_heroku_api.rb
@@ -59,7 +59,12 @@ module HerokuAPIMock
     app
   end
 
-  # overrides previously declared stubs by recreating the app using the same app id
+  # If you call create_heroku_app with an existing app id and different owners or collabs
+  # it will rewrite the mocked responses for that app id to reflect the change in ownership or
+  # collaborators.
+  # This method  calls create to rewrite the mocked collab response for a given app,
+  # with the goal of being more obvious that an update is happening, rather than
+  # calling create_heroku_app twice in the same test.
   def update_app_collaborators(app, collaborators)
     create_heroku_app(id: app.id, collaborators: collaborators, owner: app.owner)
   end

--- a/spec/support/mock_heroku_api.rb
+++ b/spec/support/mock_heroku_api.rb
@@ -59,10 +59,12 @@ module HerokuAPIMock
     app
   end
 
-  # If you call create_heroku_app with an existing app id and different owners or collabs
-  # it will rewrite the mocked responses for that app id to reflect the change in ownership or
+  # If you call create_heroku_app with an existing app id and different owners or collabs than
+  # what's already associated with the app, it will rewrite the mocked
+  # responses for that app id to reflect the change in ownership or
   # collaborators.
-  # This method  calls create to rewrite the mocked collab response for a given app,
+
+  # This method calls create to rewrite the mocked collab response for a given app,
   # with the goal of being more obvious that an update is happening, rather than
   # calling create_heroku_app twice in the same test.
   def update_app_collaborators(app, collaborators)

--- a/spec/support/mock_heroku_api.rb
+++ b/spec/support/mock_heroku_api.rb
@@ -26,10 +26,10 @@ module HerokuAPIMock
     user
   end
 
-  HerokuMockApp = Struct.new(:id)
+  HerokuMockApp = Struct.new(:id, :owner, :collaborators)
 
-  def create_heroku_app(owner:, collaborators: [])
-    app = HerokuMockApp.new(SecureRandom.uuid)
+  def create_heroku_app(owner:, collaborators: [], id: SecureRandom.uuid)
+    app = HerokuMockApp.new(id, owner, collaborators)
     app_response = {
       "name" => "example",
       "owner" => {
@@ -57,6 +57,11 @@ module HerokuAPIMock
       .to_return(body: MultiJson.encode(collab_response))
 
     app
+  end
+
+  # overrides previously declared stubs by recreating the app using the same app id
+  def update_app_collaborators(app, collaborators)
+    create_heroku_app(id: app.id, collaborators: collaborators, owner: app.owner)
   end
 
   def stub_heroku_api_request(method, url, api_key: nil)


### PR DESCRIPTION
## Context

Currently we send follow up messages to everyone who was on the original message, even if that collaborator has since been removed from the app. This fixes that by checking collaborators on the message against what API says current collaborators are.

I talked to Sepi about how this should work - if any of the original collabs exist, only send it to them. If none of the original collabs exist, send to all new collaborators. Details in the GUS chatter feed.

## SOC2
https://gus.my.salesforce.com/a07B00000077AJJIA2