### PR TITLE
Restore current_collabs memoization to reduce rate limiting

### DIFF
--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -49,7 +49,7 @@ module Mediators::Followups
     end
 
     def current_collabs
-      Mediators::Messages::UserFinder.from_message(message).call
+      @current_collabs ||= Mediators::Messages::UserFinder.from_message(message).call
     end
   end
 end

--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -45,7 +45,7 @@ module Mediators::Followups
     end
 
     def current_collab_hids
-      @current_collabs ||= current_collabs.map {|c| c.user.heroku_id }
+      @current_collab_hids ||= current_collabs.map {|c| c.user.heroku_id }
     end
 
     def current_collabs

--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -45,7 +45,7 @@ module Mediators::Followups
     end
 
     def current_collab_hids
-      current_collabs.map {|c| c.user.heroku_id }
+      @current_collabs ||= current_collabs.map {|c| c.user.heroku_id }
     end
 
     def current_collabs


### PR DESCRIPTION
Follow up to https://github.com/heroku/telex/pull/126/files#diff-edeba7de31ff7492351ba5f219a5b183R52 in order to reduce rate limiting from API.

SOC2: https://heroku.slack.com/archives/C019CQ7CH1C/p1598502143175600