### PR TITLE
Add check for staging team owners

### DIFF
--- a/lib/mediators/messages/app_user_finder.rb
+++ b/lib/mediators/messages/app_user_finder.rb
@@ -25,11 +25,16 @@ module Mediators::Messages
 
     def owners
       owner = extract_user(:owner, app_info.fetch('owner'))
-      if owner[:email].end_with?('@herokumanager.com')
+      if team?(owner[:email])
         team_users(owner[:email])
       else
         [ owner ]
       end
+    end
+
+    def team?(email)
+      email.end_with?('@herokumanager.com') ||
+        Config.deployment == 'staging' && email.end_with?('@staging.herokumanager.com')
     end
 
     def team_users(owner_email)


### PR DESCRIPTION
During incident 2100, we weren't able to complete our testing of sending messages to team admins on telex staging because it's hardcoded to look for the production `herokumanager.com` email when deciding whether to expand the owner to the list of team admins.

This hopefully allows for staging testing in the future.

SOC2: https://heroku.slack.com/archives/C019CQ7CH1C/p1598485588132700