### PR TITLE
Mark all as read

### DIFF
--- a/lib/endpoints/user_api/notifications.rb
+++ b/lib/endpoints/user_api/notifications.rb
@@ -14,9 +14,8 @@ module Endpoints
 
       patch '/mark-all-as-read' do
         redis_retry do
-          # note = Mediators::Notifications::ReadStatusUpdater.run(notification: get_note(id), read_status: get_status)
-          updated_count = get_all_notes.update(read_at: DateTime.now)
-          encode({updated: updated_count})
+          updated = Mediators::Notifications::ReadAll.run(user: current_user)
+          encode({updated: updated})
         end
       end
 
@@ -52,10 +51,6 @@ module Endpoints
 
     def current_user
       Pliny::RequestStore.store.fetch(:current_user)
-    end
-
-    def get_all_notes
-      ::Notification.where(user_id: current_user.id, read_at: nil)
     end
 
     def get_note(id)

--- a/lib/endpoints/user_api/notifications.rb
+++ b/lib/endpoints/user_api/notifications.rb
@@ -12,6 +12,14 @@ module Endpoints
         end
       end
 
+      patch '/mark-all-as-read' do
+        redis_retry do
+          # note = Mediators::Notifications::ReadStatusUpdater.run(notification: get_note(id), read_status: get_status)
+          updated_count = get_all_notes.update(read_at: DateTime.now)
+          encode({updated: updated_count})
+        end
+      end
+
       patch '/:id' do |id|
         redis_retry do
           note = Mediators::Notifications::ReadStatusUpdater.run(notification: get_note(id), read_status: get_status)
@@ -44,6 +52,10 @@ module Endpoints
 
     def current_user
       Pliny::RequestStore.store.fetch(:current_user)
+    end
+
+    def get_all_notes
+      ::Notification.where(user_id: current_user.id, read_at: nil)
     end
 
     def get_note(id)

--- a/lib/mediators/notifications/read_all.rb
+++ b/lib/mediators/notifications/read_all.rb
@@ -1,0 +1,21 @@
+module Mediators::Notifications
+  class ReadAll < Mediators::Base
+
+    attr_reader :user
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      notifications.update(read_at: Time.now)
+    end
+
+    def notifications
+      ::Notification
+        .where(user: user)
+        .where(read_at: nil)
+        .where(Sequel.lit("notifications.created_at > now() - '1 month'::interval"))
+    end
+
+  end
+end

--- a/spec/endpoints/user_api/notifications_spec.rb
+++ b/spec/endpoints/user_api/notifications_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Endpoints::UserAPI::Notifications do
       unread = Fabricate.times(4, :notification, user: @user, read_at: nil)
       patch "/notifications/mark-all-as-read"
       expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq(MultiJson.dump(updated: unread.count))
       unread.each do |note|
         note.reload
         expect(note.read_at).to_not be_nil

--- a/spec/endpoints/user_api/notifications_spec.rb
+++ b/spec/endpoints/user_api/notifications_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Endpoints::UserAPI::Notifications do
     end
   end
 
+  describe "PATCH /user/notifications/mark-all-as-read" do
+    it "marks all as read" do
+      unread = Fabricate.times(4, :notification, user: @user, read_at: nil)
+      patch "/notifications/mark-all-as-read"
+      expect(last_response.status).to eq(200)
+      unread.each do |note|
+        note.reload
+        expect(note.read_at).to_not be_nil
+      end
+    end
+  end
+
   describe "PATCH /user/notifications" do
     it "can set read to now" do
       note = Fabricate(:notification, user: @user, read_at: nil)

--- a/spec/mediators/notifications/read_all_spec.rb
+++ b/spec/mediators/notifications/read_all_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Mediators::Notifications::ReadAll, "#call" do
+
+  let(:mediator) { described_class.new(user: user) }
+  let(:user) { Fabricate(:user) }
+
+  it "marks all recent notification as read" do
+    count = 6
+    notifications = Fabricate.times(count, :notification, user: user, read_at: nil)
+    result = mediator.call
+    expect(result).to eq(count)
+
+    notifications.each do |note|
+      note.reload
+      expect(note.read_at).to be_within(1.second).of(Time.now)
+    end
+  end
+
+  it "only marks notifications read for the user passed in" do
+    to_be_read = Fabricate(:notification, user: user, read_at: nil)
+    another_user = Fabricate(:user)
+    to_not_be_read = Fabricate(:notification, user: another_user, read_at: nil)
+    result = mediator.call
+    expect(result).to eq(1)
+
+    to_be_read.reload
+    expect(to_be_read.read_at).to be_within(1.second).of(Time.now)
+
+    to_not_be_read.reload
+    expect(to_not_be_read.read_at).to be_nil
+  end
+
+  it "ignores notifications that are no longer valid" do
+    one_month_ago = Date.today << 1
+    notification = Fabricate(:notification, user: user, created_at: one_month_ago)
+    result = mediator.call
+    expect(result).to_not be_nil
+    notification.reload
+    expect(notification.read_at).to be_nil
+  end
+end


### PR DESCRIPTION
GUS [W-8070355](https://gus.lightning.force.com/a07B0000008d1QVIAY)

Enterprise customers (mostly SFDC and Heroku) can have many thousands of notifications. Currently when I user visits `https://dashboard.heroku.com/notifications` they see a button that says "Mark All As Read". Dashboard enqueues a notification read request for each of the notifications for that user.

Because of other work we are doing around rate limiting (DOS protection) in particleboard we noticed large spikes in requests for certain users. Turns out, if a SFDC employee in Germany clicks "Mark All As Read" it will enqueue 21k+ notification requests from the browser.

This PR will allow dashboard to make one request instead of 25k.