### PR TITLE
Include source and deploy in log lines

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -15,7 +15,7 @@ module Config
   mandatory :heroku_api_url
   mandatory :mailgun_smtp_login
   mandatory :mailgun_smtp_password
-  mandatory :mailgun_smtp_port,      int
+  mandatory :mailgun_smtp_port, int
   mandatory :mailgun_smtp_server
 
   # Optional -- value is returned or `nil` if it wasn't present.
@@ -27,19 +27,20 @@ module Config
   optional :database_log_level
 
   # Override -- value is returned or the set default
-  override :cache_user_auth,  true,  bool
-  override :database_timeout, 10,    int
-  override :db_pool,          5,     int
-  override :force_ssl,        true,  bool
-  override :port,             5000,  int
-  override :pretty_json,      false, bool
-  override :puma_max_threads, 16,    int
-  override :puma_min_threads, 1,     int
-  override :puma_workers,     3,     int
-  override :rack_env,         'development', string
-  override :raise_errors,     false, bool
-  override :root,             File.expand_path("../../", __FILE__), string
-  override :timeout,          45,    int
-  override :versioning,       false, bool
+  override :cache_user_auth, true, bool
+  override :database_timeout, 10, int
+  override :db_pool, 5, int
+  override :force_ssl, true, bool
+  override :metric_source, "telex.local", string
+  override :port, 5000, int
+  override :pretty_json, false, bool
+  override :puma_max_threads, 16, int
+  override :puma_min_threads, 1, int
+  override :puma_workers, 3, int
+  override :rack_env, "development", string
+  override :raise_errors, false, bool
+  override :root, File.expand_path("../../", __FILE__), string
+  override :timeout, 45, int
+  override :versioning, false, bool
   override :users_endpoint_authorized_producers, "", array
 end

--- a/config/initializers/log.rb
+++ b/config/initializers/log.rb
@@ -1,3 +1,3 @@
-Pliny.default_context = {app: "telex"}
+Pliny.default_context = {app: "telex", deploy: Config.deployment, source: Config.metric_source}
 
 Pliny.log_scrubber = BlacklistHash.build(fields_to_scrub: Rollbar::Blanket.fields, scrub_urls: true)


### PR DESCRIPTION
This makes it easier to search splunk by emitting a `deploy` and gives us a `source` for differentiating metrics in librato.

[GUS](https://gus.my.salesforce.com/a07B0000008a4B3IAI)