### PR TITLE
Fix Bundler error on deploy, maybe?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.bundle
 .env
 notes*
 tags
+tmp
 /spec/failures.txt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   addressable

--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,12 @@ function main {
   set -e
 
   add_new_env_vars
-  bundle install --local
+
+  bundle config --local specific_platform true
+  bundle config --local cache_all true
+  bundle config --local cache_all_platforms true
+  bundle check > /dev/null || bundle install --local
+
   bin/rake db:setup db:migrate
 }
 


### PR DESCRIPTION
Trying to deploy to staging we're seeing the following error:

```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
```

I'm not exactly sure what to make of it, but have to assume it's a result of fixing the Bundler deprecations (and vulnerability) re: multiple `source` entries in the `Gemfile.lock` (see: #132).  This PR explicitly includes the correct platforms in the lock file, and ignores the new config necessary to set up proper dependency vending. YOLO!

[💬](https://heroku.slack.com/archives/CAJNZ67FF/p1615488921035000)