### PR TITLE
Fix sidekiq

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: bin/puma --config config/puma.rb config.ru
-worker: bin/sidekiq --tag=${DYNO:-default} --queue=default -r ./lib/application.rb 
+worker: bin/sidekiq --tag=${DYNO:-default} --queue=default,2 --queue=rollbar,1 -r ./lib/application.rb 
 clock: bin/clockwork lib/clock.rb
 # Customize the `heroku console` experience
 console: bin/console

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: bin/puma --config config/puma.rb config.ru
-worker: bin/sidekiq -g ${DYNO:-default} -i ${DYNO:-1} -r ./lib/application.rb
+worker: bin/sidekiq --tag=${DYNO:-default} --queue=default -r ./lib/application.rb 
 clock: bin/clockwork lib/clock.rb
 # Customize the `heroku console` experience
 console: bin/console

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -14,5 +14,7 @@ unless Config.rack_env == 'test'
     config.exception_level_filters.merge!(
       'Telex::Emailer::DeliveryError' => 'warning'
     )
+
+    config.use_sidekiq
   end
 end


### PR DESCRIPTION
Stop using an old, no-longer-working option when starting Sidekiq. And also wire up Rollbar so we know when errors do happen.

[SOC](https://heroku.slack.com/archives/C013THT7PFA/p1615830979163000)