### PR TITLE
Fix up SQL literal in Recipients::Limiter

### DIFF
--- a/lib/mediators/recipients/limiter.rb
+++ b/lib/mediators/recipients/limiter.rb
@@ -28,10 +28,11 @@ module Mediators::Recipients
       end
     end
 
-  private
+    private
+
     def created_today
-      Recipient.where("app_id = ? and ? <= created_at and created_at < ?",
-                      app_info.fetch("id"), today, tomorrow)
+      Recipient.where(Sequel.lit("app_id = ? and ? <= created_at and created_at < ?",
+                      app_info.fetch("id"), today, tomorrow))
     end
 
     def today

--- a/spec/mediators/recipients/limiter_spec.rb
+++ b/spec/mediators/recipients/limiter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mediators::Recipients::Limiter do
     end
 
     it "does not raise an error when no limit is hit" do
-      @limiter.call
+      expect { @limiter.call }.not_to raise_error
     end
 
     it "raises LimitError with a limit hit" do


### PR DESCRIPTION
This commit fixes up the SQL literal in Recipients::Limiter, that was
missed when migrating to Ruby 2.7.3 and Sequel 5.

It also renames the spec to be more discoverable – it was not being run
in CI due to not matching the glob pattern `spec/**/*_spec.rb` used in
CI.

Ref: https://heroku.slack.com/archives/C1RS6AUDR/p1619776287479800