### PR TITLE
Don't retry DB cleanup job if it fails

### DIFF
--- a/lib/jobs/cleanup.rb
+++ b/lib/jobs/cleanup.rb
@@ -1,6 +1,8 @@
 module Jobs
   class Cleanup
     include Sidekiq::Worker
+    # Scheduled job will run again in 12 hours if it fails:
+    sidekiq_options retry: false
 
     def perform
       Mediators::Messages::Cleanup.run


### PR DESCRIPTION
These DB cleanup jobs run every 12 hours in lib/clock.rb. So there's no reason to retry if it fails -- the next scheduled job will hopefully run instead. We should see job failures in Rollbar, as well.

SOC2:
https://heroku.slack.com/archives/C1RS6AUDR/p1619819237017300