### PR TITLE
Increase cleanup job statement time to 15 minutes

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 ADDITIONAL_API_HEADERS={"User":"{{user}}"}
 API_KEY_HMAC_SECRET=testsecretCwmQtCn4k6cNYfXicex0jP79Bd9qlGhMOWMRXT0AmoU0oJD0fd9t1fKfOLnGaFHc1KEHpcIsKWsQOv5+dLV1w/74aK==
 APP_NAME=telex
+CLEANUP_JOB_TIMEOUT=10s
 DATABASE_URL=postgres://localhost/telex-test
 DEPLOYMENT=test
 FORCE_SSL=false

--- a/config/config.rb
+++ b/config/config.rb
@@ -43,4 +43,5 @@ module Config
   override :timeout, 45, int
   override :versioning, false, bool
   override :users_endpoint_authorized_producers, "", array
+  override :cleanup_job_timeout, "15min", string
 end

--- a/lib/mediators/messages/cleanup.rb
+++ b/lib/mediators/messages/cleanup.rb
@@ -8,7 +8,7 @@ module Mediators::Messages
       db = Sequel::Model.db
       db.transaction do
         # This takes a long time, so up the timeout for just this transaction:
-        db["SET LOCAL statement_timeout = '15min'"].all
+        db["SET LOCAL statement_timeout = '#{Config.cleanup_job_timeout}'"].all
         db["DELETE FROM followups
               USING messages
               WHERE messages.id=followups.message_id

--- a/lib/mediators/messages/cleanup.rb
+++ b/lib/mediators/messages/cleanup.rb
@@ -7,6 +7,8 @@ module Mediators::Messages
     def call
       db = Sequel::Model.db
       db.transaction do
+        # This takes a long time, so up the timeout for just this transaction:
+        db["SET LOCAL statement_timeout = '15min'"].all
         db["DELETE FROM followups
               USING messages
               WHERE messages.id=followups.message_id


### PR DESCRIPTION
The Sequel default of 10 second timeout is way too low for this with production data.