### PR TITLE
Find or create Notifications when new collabs found

### DIFF
--- a/lib/mediators/followups/notification_updater.rb
+++ b/lib/mediators/followups/notification_updater.rb
@@ -36,8 +36,8 @@ module Mediators::Followups
       current_collabs.each do |c|
         if !notifiable_hids.include?(c.user.heroku_id)
           # not using the notification mediator here because it sends an email,
-          # which we also do in this mediator
-          new_notifiables << Notification.create(notifiable: c.user, message_id: message.id)
+          # which we also do in this mediator. Handle duplicates by finding existing:
+          new_notifiables << Notification.find_or_create(user: c.user, message_id: message.id)
         end
       end
 


### PR DESCRIPTION
Prevents an exception in Rollbar that looks like:

Sequel::ValidationFailed: user and message is already taken
File /app/lib/mediators/followups/notification_updater.rb line 40 in block in create_notifications_for_all_collabs
File /app/lib/mediators/followups/notification_updater.rb line 36 in each
File /app/lib/mediators/followups/notification_updater.rb line 36 in create_notifications_for_all_collabs
File /app/lib/mediators/followups/notification_updater.rb line 22 in update_notifications
File /app/lib/mediators/followups/notification_updater.rb line 10 in call
(etc)

It is not easy to set up a test to get into this state (did not detect
the notifications on line 19 but the notification now exists and
prevents the validation on line 40), other than to stub out the
Notification model's `create` method to raise the error. So I am fixing this without a test
exercising the bug.