### PR TITLE
Log job queue latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Telex is currently in maintenance only mode. Web Services handles maintenance
 updates and making sure the system is functioning properly but no new features
 are being added.
 
-If you have issues or questions, feel free to use `/pd ping` in `#core-services`
+If you have issues or questions, feel free to use `/pd ping` in `#web-services`
 on Slack for assistance.
 
 ## Setup

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -7,6 +7,7 @@ module Clockwork
     Thread.new do
       stats = Sidekiq::Stats.new
       Telex::Sample.sample "jobs.queue", value: stats.enqueued
+      Telex::Sample.sample "jobs.queue-latency", value: "#{stats.default_queue_latency}s"
     end
   end
 


### PR DESCRIPTION
This was already available in the `Sidekiq::Stats` instance in the `lib/clock.rb` file, we just had to log it out. 

There's no tests for `lib/clock.rb`, so I have not added any new ones here. However, I have run this locally and threw a bunch of jobs on the queue for it to work, causing it to output:

```
...
source=telex.local sample#telex.production.jobs.queue-latency=1.4170207977294922s
...
source=telex.local sample#telex.production.jobs.queue-latency=0s
```

(These lines have been cleaned up / truncated to show just the metric)